### PR TITLE
fixed leaderboard to track current year

### DIFF
--- a/views/shifts.ejs
+++ b/views/shifts.ejs
@@ -41,7 +41,7 @@
                                     <div class="dropdown">
                                         <button class="btn btn-default dropdown-toggle" type="button" id="dropdownMenu1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
                                             <!-- <span id="the_year">2022</span> -->
-                                            <span id="the_year"><%= new Date(2030, 1, 1).getFullYear()%></span>
+                                            <span id="the_year"><%= new Date().getFullYear()%></span>
                                             <span class="caret"></span>
                                         </button>
                                         <!-- <ul class="dropdown-menu" style="background-color:#fff;letter-spacing:normal;">
@@ -55,7 +55,7 @@
                                         </ul> -->
                                         
                                         <ul class="dropdown-menu" style="background-color:#fff;letter-spacing:normal;">
-                                            <% for(var yr = new Date(2030, 1, 1).getFullYear(); yr >= 2016; yr--) { %>
+                                            <% for(var yr = new Date().getFullYear(); yr >= 2016; yr--) { %>
                                                 <li><a href="#"><%= yr%></a></li>
                                             <% } %>
                                         </ul>
@@ -515,7 +515,7 @@
         const stats = await CalcEstShifts(`<%- JSON.stringify(instInfo) %>`);
         console.log(stats);
         // initialize the table at current year
-        FillAggregates("#aggregate_table_body", "<%= new Date(2030, 1, 1).getFullYear() %>", "<%= user.institute %>");
+        FillAggregates("#aggregate_table_body", "<%= new Date().getFullYear() %>", "<%= user.institute %>");
         $('.dropdown-menu a').click(function(){
             $('#the_year').text($(this).text());
             FillAggregates("#aggregate_table_body", $(this).text(), "<%= user.institute %>");

--- a/views/shifts.ejs
+++ b/views/shifts.ejs
@@ -40,10 +40,11 @@
                                 <th id="table_head_this_year">
                                     <div class="dropdown">
                                         <button class="btn btn-default dropdown-toggle" type="button" id="dropdownMenu1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-                                            <span id="the_year">2022</span>
+                                            <!-- <span id="the_year">2022</span> -->
+                                            <span id="the_year"><%= new Date().getFullYear()%></span>
                                             <span class="caret"></span>
                                         </button>
-                                        <ul class="dropdown-menu" style="background-color:#fff;letter-spacing:normal;">
+                                        <!-- <ul class="dropdown-menu" style="background-color:#fff;letter-spacing:normal;">
                                             <li><a href="#">2022</a></li>
                                             <li><a href="#">2021</a></li>
                                             <li><a href="#">2020</a></li>
@@ -51,7 +52,14 @@
                                             <li><a href="#">2018</a></li>
                                             <li><a href="#">2017</a></li>
                                             <li><a href="#">2016</a></li>
+                                        </ul> -->
+                                        
+                                        <ul class="dropdown-menu" style="background-color:#fff;letter-spacing:normal;">
+                                            <% for(var yr = new Date().getFullYear(); yr >= 2016; yr--) { %>
+                                                <li><a href="#"><%= yr%></a></li>
+                                            <% } %>
                                         </ul>
+                                        
                                     </div>
                                 </th>
                             </thead>

--- a/views/shifts.ejs
+++ b/views/shifts.ejs
@@ -41,7 +41,7 @@
                                     <div class="dropdown">
                                         <button class="btn btn-default dropdown-toggle" type="button" id="dropdownMenu1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
                                             <!-- <span id="the_year">2022</span> -->
-                                            <span id="the_year"><%= new Date().getFullYear()%></span>
+                                            <span id="the_year"><%= new Date(2030, 1, 1).getFullYear()%></span>
                                             <span class="caret"></span>
                                         </button>
                                         <!-- <ul class="dropdown-menu" style="background-color:#fff;letter-spacing:normal;">
@@ -55,7 +55,7 @@
                                         </ul> -->
                                         
                                         <ul class="dropdown-menu" style="background-color:#fff;letter-spacing:normal;">
-                                            <% for(var yr = new Date().getFullYear(); yr >= 2016; yr--) { %>
+                                            <% for(var yr = new Date(2030, 1, 1).getFullYear(); yr >= 2016; yr--) { %>
                                                 <li><a href="#"><%= yr%></a></li>
                                             <% } %>
                                         </ul>
@@ -515,7 +515,7 @@
         const stats = await CalcEstShifts(`<%- JSON.stringify(instInfo) %>`);
         console.log(stats);
         // initialize the table at current year
-        FillAggregates("#aggregate_table_body", '2022', "<%= user.institute %>");
+        FillAggregates("#aggregate_table_body", "<%= new Date(2030, 1, 1).getFullYear() %>", "<%= user.institute %>");
         $('.dropdown-menu a').click(function(){
             $('#the_year').text($(this).text());
             FillAggregates("#aggregate_table_body", $(this).text(), "<%= user.institute %>");


### PR DESCRIPTION
Leaderboard and its dropdown menu now display the current year and shifts for every year since 2016. No need to replace specific year in code.