### PR TITLE
edited previous time message

### DIFF
--- a/routes/users.js
+++ b/routes/users.js
@@ -303,7 +303,8 @@ router.post('/:page/:userid/updateContactInfoAdmin', ensureAuthenticated, functi
       idoc['institute'] = req.body.institute;
       if (idoc['institute'] != previous_doc['institute']) {
         changes += 'Institute: ' + req.body.institute + '<br>';
-        prevtimestr = req.body.prevTime + "Was at " + previous_doc['institute'] + " until " + moment().format("MMM YYYY") + ". ";
+        prevtimestr = req.body.prevTime;
+        // prevtimestr = req.body.prevTime + "Was at " + previous_doc['institute'] + " until " + moment().format("MMM YYYY") + ". ";
         idoc['previous_time'] = prevtimestr;
         previously += 'Previous Time: ' + previous_doc['institute'] + '<br>';
         changes += 'Previous Time: ' + prevtimestr + '<br>';


### PR DESCRIPTION
Instead of providing a formatted message, the message displayed under "explanations" for a member that has changed institutes should only display the information about previous time inputted by the editor. This could be an issue if editors choose not to include information about previous time when editing information about members/users.