### PR TITLE
fix automatically generated message

### DIFF
--- a/routes/users.js
+++ b/routes/users.js
@@ -305,9 +305,11 @@ router.post('/:page/:userid/updateContactInfoAdmin', ensureAuthenticated, functi
         changes += 'Institute: ' + req.body.institute + '<br>';
         prevtimestr = req.body.prevTime;
         // prevtimestr = req.body.prevTime + "Was at " + previous_doc['institute'] + " until " + moment().format("MMM YYYY") + ". ";
+        prevtimestr = "Was at " + previous_doc['institute'] + " until " + moment().format("MMM YYYY") + ". ";
+
         idoc['previous_time'] = prevtimestr;
         previously += 'Previous Time: ' + previous_doc['institute'] + '<br>';
-        changes += 'Previous Time: ' + prevtimestr + '<br>';
+        changes += 'Previous Time: ' + prevtimestr + '<br>'; 
       } else {
         if (req.body.prevTime != null && req.body.prevTime != "") {
           idoc['previous_time'] = req.body.prevTime;

--- a/routes/users.js
+++ b/routes/users.js
@@ -303,7 +303,7 @@ router.post('/:page/:userid/updateContactInfoAdmin', ensureAuthenticated, functi
       idoc['institute'] = req.body.institute;
       if (idoc['institute'] != previous_doc['institute']) {
         changes += 'Institute: ' + req.body.institute + '<br>';
-        prevtimestr = req.body.prevTime;
+        // prevtimestr = req.body.prevTime;
         // prevtimestr = req.body.prevTime + "Was at " + previous_doc['institute'] + " until " + moment().format("MMM YYYY") + ". ";
         prevtimestr = "Was at " + previous_doc['institute'] + " until " + moment().format("MMM YYYY") + ". ";
 


### PR DESCRIPTION
Automatically generated message mailed when a user's information is updated should remain as specified in the wiki.